### PR TITLE
init: don't use fork for launching /init

### DIFF
--- a/init/Android.mk
+++ b/init/Android.mk
@@ -23,7 +23,8 @@ LOCAL_SRC_FILES := \
     init_files.cpp \
     init_io.cpp \
     init_main.cpp \
-    ../extract_ramdisk/extract_ramdisk.cpp
+    ../extract_ramdisk/extract_ramdisk.cpp \
+    ../keycheck/keycheck.cpp
 
 LOCAL_C_INCLUDES := \
     ../extract_ramdisk

--- a/init/init_board_common.h
+++ b/init/init_board_common.h
@@ -28,8 +28,8 @@
 #define SBIN_CPIO_RECOVERY "/sbin/ramdisk-recovery.cpio"
 
 // Constants: keycheck commands
-#define KEYCHECK_RECOVERY_BOOT_ONLY (41 << 8)
-#define KEYCHECK_RECOVERY_FOTA_BOOT (42 << 8)
+#define KEYCHECK_RECOVERY_BOOT_ONLY 41
+#define KEYCHECK_RECOVERY_FOTA_BOOT 42
 
 // Class: init_board_common
 class init_board_common

--- a/init/init_exec.cpp
+++ b/init/init_exec.cpp
@@ -72,3 +72,9 @@ int system_exec_kill(pid_t pid, uint8_t timeout)
     kill(pid, SIGTERM);
     return 0;
 }
+
+// Function: binary execution without forking, so as to maintain same pid
+void system_exec_no_fork(const char* argv[])
+{
+    execv(argv[0], const_cast<char* const*>(&argv[0]));
+}

--- a/init/init_main.cpp
+++ b/init/init_main.cpp
@@ -21,6 +21,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "../keycheck/keycheck.h"
+
 #include "init_board.h"
 #include "init_prototypes.h"
 
@@ -80,15 +82,11 @@ int main(int argc, char** __attribute__((unused)) argv)
     if (!recoveryBoot && !multiRomBoot && !chargerBoot)
     {
 #if KEYCHECK_ENABLED
-        // Listen for volume keys
-        const char* argv_keycheck[] = { EXEC_KEYCHECK, nullptr };
-        pid_t keycheck_pid = system_exec_bg(argv_keycheck);
-
         // Board keycheck introduction
         init_board.introduce_keycheck();
 
-        // Retrieve keycheck result
-        keycheckStatus = system_exec_kill(keycheck_pid, KEYCHECK_TIMEOUT);
+        // Listen for volume keys and retrieve the result
+        keycheckStatus = keycheck_timed(KEYCHECK_TIMED, KEYCHECK_TIMEOUT);
         recoveryBoot = (keycheckStatus == KEYCHECK_RECOVERY_BOOT_ONLY ||
                 keycheckStatus == KEYCHECK_RECOVERY_FOTA_BOOT);
 

--- a/init/init_main.cpp
+++ b/init/init_main.cpp
@@ -169,8 +169,9 @@ int main(int argc, char** __attribute__((unused)) argv)
         dir_unlink_r("/dev", false);
 
         // Launch ramdisk /init
+        // since this is the final step, launch /init in the same process
         const char* argv_init[] = { "/init", nullptr };
-        system_exec(argv_init);
+        system_exec_no_fork(argv_init);
     }
 
     return 0;

--- a/init/init_prototypes.h
+++ b/init/init_prototypes.h
@@ -41,6 +41,7 @@ void write_date(const char* path, bool append = false);
 int system_exec(const char* argv[]);
 pid_t system_exec_bg(const char* argv[]);
 int system_exec_kill(pid_t pid, uint8_t timeout = 0);
+void system_exec_no_fork(const char* argv[]);
 
 // Prototype: elf ramdisk extraction
 int extract_ramdisk(int argc, const char** argv);


### PR DESCRIPTION
this causes problems on stock roms where shutdown and reboot cause the
device to crash and restart